### PR TITLE
Typehint of array would seem to save a few cycles.

### DIFF
--- a/src/array_column.php
+++ b/src/array_column.php
@@ -27,7 +27,7 @@ if (!function_exists('array_column')) {
      *                        of the column, or it may be the string key name.
      * @return array
      */
-    function array_column($input = null, $columnKey = null, $indexKey = null)
+    function array_column(array $input = null, $columnKey = null, $indexKey = null)
     {
         // Using func_get_args() in order to check for proper number of
         // parameters and trigger errors exactly as the built-in array_column()
@@ -37,14 +37,6 @@ if (!function_exists('array_column')) {
 
         if ($argc < 2) {
             trigger_error("array_column() expects at least 2 parameters, {$argc} given", E_USER_WARNING);
-            return null;
-        }
-
-        if (!is_array($params[0])) {
-            trigger_error(
-                'array_column() expects parameter 1 to be array, ' . gettype($params[0]) . ' given',
-                E_USER_WARNING
-            );
             return null;
         }
 


### PR DESCRIPTION
Is there a reason to NOT use a typehint? Considering that the original code actively refuses anything not matchable to is_array(), the typehint (at least from a PHP developer's perspective) would seem to be doing the same thing.